### PR TITLE
diag: fix issue with diagnostics container

### DIFF
--- a/start-miner.sh
+++ b/start-miner.sh
@@ -6,7 +6,7 @@ wget \
 
 PUBLIC_KEYS=$(/opt/miner/bin/miner print_keys)
 [ $? -ne 0 ] && exit 1
-echo "$PUBLIC_KEYS" > /var/data/public_keys
+echo $PUBLIC_KEYS > /var/data/public_keys
 
 /opt/miner/gen-region.sh &
 


### PR DESCRIPTION
remove the inverted commas around public keys variable to fix the broken diagnostics container in https://github.com/NebraLtd/hm-diag/issues/75