### PR TITLE
Removes hard coded release

### DIFF
--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -1,25 +1,27 @@
 name: Compile Docker Images
 
-on: [push]
+on:
+  push:
+    tags:
+       - '*GA'
 
 jobs:
   main:
     runs-on: ubuntu-20.04
     steps:
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -28,6 +30,6 @@ jobs:
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest
-      -
-        name: Image digest
+
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -26,8 +26,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          build-args:
-            - HELIUM_GA_RELEASE=${{ github.event.release.tag_name }}
+          build-args: |
+            HELIUM_GA_RELEASE=${{ github.event.release.tag_name }}
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest

--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -9,6 +9,19 @@ jobs:
   main:
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Check output
+        env:
+          HELIUM_GA_RELEASE: ${{ steps.vars.outputs.tag }}
+        run: |
+          echo $HELIUM_GA_RELEASE
+          echo ${{ steps.vars.outputs.tag }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -27,7 +40,7 @@ jobs:
         with:
           push: true
           build-args: |
-            HELIUM_GA_RELEASE=${{ github.event.release.tag_name }}
+            HELIUM_GA_RELEASE:${{ steps.vars.outputs.tag }}
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest

--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -1,27 +1,11 @@
 name: Compile Docker Images
 
-on:
-  push:
-    tags:
-       - '*GA'
+on: [push]
 
 jobs:
   main:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set output
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-      - name: Check output
-        env:
-          HELIUM_GA_RELEASE: ${{ steps.vars.outputs.tag }}
-        run: |
-          echo $HELIUM_GA_RELEASE
-          echo ${{ steps.vars.outputs.tag }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -39,8 +23,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          build-args: |
-            HELIUM_GA_RELEASE:${{ steps.vars.outputs.tag }}
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest

--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          build-args: ${{ github.event.release.tag_name }}
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest

--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -26,7 +26,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          build-args: ${{ github.event.release.tag_name }}
+          build-args:
+            - HELIUM_GA_RELEASE=${{ github.event.release.tag_name }}
           tags: |
                 nebraltd/hm-miner:${{ github.sha }}
                 nebraltd/hm-miner:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM quay.io/team-helium/miner:miner-arm64_2021.09.03.0_GA
+FROM quay.io/team-helium/miner:miner-arm64_${HELIUM_GA_RELEASE}
 
 WORKDIR /opt/miner
 
-COPY docker.config /opt/miner/releases/2021.09.03.0_GA/sys.config
+COPY docker.config /opt/miner/releases/${HELIUM_GA_RELEASE}/sys.config
 COPY start-miner.sh /opt/miner/start-miner.sh
 COPY gen-region.sh /opt/miner/gen-region.sh
+
+ARG HELIUM_GA_RELEASE
+ENV HELIUM_GA_RELEASE=${HELIUM_GA_RELEASE}
 
 ENTRYPOINT ["/opt/miner/start-miner.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM quay.io/team-helium/miner:miner-arm64_${HELIUM_GA_RELEASE}
+ARG HELIUM_GA_RELEASE=2021.09.03.0_GA
+
+FROM quay.io/team-helium/miner:miner-arm64_$HELIUM_GA_RELEASE
 
 WORKDIR /opt/miner
 
-COPY docker.config /opt/miner/releases/${HELIUM_GA_RELEASE}/sys.config
+COPY docker.config /opt/miner/releases/$HELIUM_GA_RELEASE/sys.config
 COPY start-miner.sh /opt/miner/start-miner.sh
 COPY gen-region.sh /opt/miner/gen-region.sh
 
-ARG HELIUM_GA_RELEASE
-ENV HELIUM_GA_RELEASE=${HELIUM_GA_RELEASE}
+ENV HELIUM_GA_RELEASE=$HELIUM_GA_RELEASE
 
 ENTRYPOINT ["/opt/miner/start-miner.sh"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ $ git push origin 2021.09.03.0_GA
 ```
 
 (Replace "2021.09.03.0_GA" with the desired release.)
+
+This will in turn create a new GitHub Release and build the package.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # hm-miner
+
 Helium Miner Container
+
+## Creating a release
+
+To create a new release, run the following commands:
+
+```
+# git tag 2021.09.03.0_GA
+$ git push origin 2021.09.03.0_GA
+```
+
+(Replace "2021.09.03.0_GA" with the desired release.)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ Helium Miner Container
 
 ## Creating a release
 
-To create a new release, run the following commands:
-
-```
-# git tag 2021.09.03.0_GA
-$ git push origin 2021.09.03.0_GA
-```
-
-(Replace "2021.09.03.0_GA" with the desired release.)
-
-This will in turn create a new GitHub Release and build the package.
+* Create a new branch
+* Edit the first line of `Dockerfile` to point to the new GA release
+* Push and create a new PR

--- a/start-miner.sh
+++ b/start-miner.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 if [ "$(df -h /var/data/ | tail -1 | awk '{print $5}' | tr -d '%')" -ge 80 ]; then
-  rm -rf /var/data/* 
+  rm -rf /var/data/*
 fi
 
 wget \
-    -O /opt/miner/releases/2021.09.03.0_GA/sys.config \
+    -O "/opt/miner/releases/$HELIUM_GA_RELEASE/sys.config" \
     "${OVERRIDE_CONFIG_URL:=https://helium-assets.nebra.com/docker.config}"
 
 if ! PUBLIC_KEYS=$(/opt/miner/bin/miner print_keys)


### PR DESCRIPTION
**Why**
It's a massive PITA to update all release references.

**How**
We can solve this by moving to build args that populates the env variable.

