### PR TITLE
Adds release to lsb-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY gen-region.sh /opt/miner/gen-region.sh
 ARG HELIUM_GA_RELEASE
 ENV HELIUM_GA_RELEASE $HELIUM_GA_RELEASE
 
-RUN echo "$HELIUM_GA_RELEASE" > /dev/lsb-release
+RUN echo "$HELIUM_GA_RELEASE" > /etc/lsb-release
 
 ENTRYPOINT ["/opt/miner/start-miner.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ COPY gen-region.sh /opt/miner/gen-region.sh
 ARG HELIUM_GA_RELEASE
 ENV HELIUM_GA_RELEASE $HELIUM_GA_RELEASE
 
+RUN echo "$HELIUM_GA_RELEASE" > /dev/lsb-release
+
 ENTRYPOINT ["/opt/miner/start-miner.sh"]


### PR DESCRIPTION
**Why**
This file is needed to read back the release version from the Helium API

**How**
We just write the rlease to `/etc/lsb-release`

**References**
* https://github.com/NebraLtd/hm-pyhelper/issues/2