### PR TITLE
Speeds up and improves startup logic

### DIFF
--- a/dbus-wait.sh
+++ b/dbus-wait.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env sh
 
 wait_for_dbus() {
-	while true; do
-		dbus-send --system \
-			  --print-reply \
-			  --dest=org.freedesktop.DBus \
-			  /org/freedesktop/DBus \
-			  org.freedesktop.DBus.ListNames
+    while true; do
+        dbus-send --system \
+              --print-reply \
+              --dest=org.freedesktop.DBus \
+              /org/freedesktop/DBus \
+              org.freedesktop.DBus.ListNames
 
                 dbus_wait=$?
-		if [ "$dbus_wait" -eq 0 ]; then
-			break;
-		else
-			sleep 0.1
-		fi
-	done
+        if [ "$dbus_wait" -eq 0 ]; then
+            break;
+        else
+            sleep 0.1
+        fi
+    done
 
-	echo "DBus is now accepting connections"
+    echo "DBus is now accepting connections"
 }


### PR DESCRIPTION
With the introduction of ECC provisioning inside the hm-diag repo (see https://github.com/NebraLtd/hm-diag/pull/162), we can need to rework the logic for starting the miner. 

This PR includes the following:

* (Changes hard tabs to soft tabs in `dbus-wait.sh`)
* Forces the miner to wait for hm-diag to start properly, which in turn is blocked by the key provisioning