### PR TITLE
feat: add build arch ARG and matrix build

### DIFF
--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -2,10 +2,12 @@ name: Compile Docker Images
 
 on: 
   push:
-  release:
 
 jobs:
   main:
+    strategy:
+      matrix:
+        args: [arm64, amd64]
     runs-on: ubuntu-20.04
     permissions:
       packages: write
@@ -40,14 +42,16 @@ jobs:
           flavor: |
             latest=true
           tags: |
-            type=sha,prefix=
-            type=sha,format=long,prefix=
-            type=ref,event=tag
+            type=sha,prefix=${{ matrix.args }}-
+            type=sha,format=long,prefix=${{ matrix.args }}-
+            type=ref,event=tag,prefix=${{ matrix.args }}-
+            type=raw,value=${{ matrix.args }}-latest
 
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          build-args: BUILD_ARCH=${{ matrix.args }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG HELIUM_GA_RELEASE=2021.11.21.2
+ARG BUILD_ARCH=arm64
 
-FROM quay.io/team-helium/miner:miner-arm64_"$HELIUM_GA_RELEASE"_GA
+FROM quay.io/team-helium/miner:miner-"$BUILD_ARCH"_"$HELIUM_GA_RELEASE"_GA
 
 WORKDIR /opt/miner
 
@@ -9,6 +10,7 @@ ENV HELIUM_GA_RELEASE $HELIUM_GA_RELEASE
 
 COPY docker.config /opt/miner/releases/"$HELIUM_GA_RELEASE"/sys.config
 COPY docker.config.rockpi /opt/miner/docker.config.rockpi
+COPY docker.config.5g /opt/miner/docker.config.5g
 COPY *.sh /opt/miner/
 
 RUN echo "$HELIUM_GA_RELEASE" > /etc/lsb_release

--- a/docker.config.5g
+++ b/docker.config.5g
@@ -1,0 +1,18 @@
+%% -*- erlang -*-
+[
+  "config/sys.config",
+  {lager,
+    [
+      {log_root, "/var/log/miner"}
+    ]},
+  {blockchain,
+    [
+      {key, {tpm, [{key_path, "HS/SRK/MinerKey"}]}}
+    ]},
+  {miner,
+    [
+      {use_ebus, true},
+      {radio_device, { {0,0,0,0}, 1680,
+        {0,0,0,0}, 31341} }
+    ]}
+].

--- a/start-miner.sh
+++ b/start-miner.sh
@@ -12,6 +12,9 @@ OVERRIDE_CONFIG_URL="${RASPBERRYPI_MINER_CONFIG_URL:-https://helium-assets.nebra
 if [ "$BALENA_DEVICE_TYPE" = "rockpi-4b-rk3399" ]; then
   cp /opt/miner/docker.config.rockpi "/opt/miner/releases/$HELIUM_GA_RELEASE/sys.config"
   OVERRIDE_CONFIG_URL="${ROCKPI_MINER_CONFIG_URL:-https://helium-assets.nebra.com/docker.config.rockpi}"
+elif [ "$BALENA_DEVICE_TYPE" = "intel-nuc" ]; then
+  cp /opt/miner/docker.config.5g "/opt/miner/releases/$HELIUM_GA_RELEASE/sys.config"
+  OVERRIDE_CONFIG_URL="${5G_MINER_CONFIG_URL:-https://helium-assets.nebra.com/docker.config.5g}"
 fi
 
 wget \


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Support amd64 builds and 5g hardware

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- add a build arch build ARG so we can build for multiple architectures
- build using strategy matrix in action
- add 5g config
- copy 5g config into container
- check for x86_64 device type (intel-nuc) and use correct config based on that
- update tags output in image compile action

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Closes: #57
https://github.com/NebraLtd/helium-miner-software/pull/263